### PR TITLE
Add audit check step to CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,6 +90,18 @@ jobs:
         uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check audit results
+        run: |
+          audit_output=$(cargo audit --json)
+          echo "$audit_output"
+          if [[ $audit_output == *"\"found\":false"* ]]; then
+            echo "No vulnerabilities were found"
+          else
+            echo "Vulnerabilities were found"
+          fi
+          if [[ $audit_output == *"\"kind\":\"unmaintained\""* ]]; then
+            echo "Warning: Unmaintained packages were found"
+          fi
 
   # docs:
   #   needs: [test, security_audit]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { version = "0.12.5", features = ["blocking", "json"] }
 serde_json = "1.0.121"
 sourceview = "0.9"
 tokio = { version = "1.39.2", features = ["full"] }
+yaml-rust2 = "0.8.1"
 webkit2gtk = "0.11"
 
 [dependencies.gtk]


### PR DESCRIPTION
The CI/CD workflow has been updated to include a new step for checking audit results. This step runs the `cargo audit` command and outputs the results. If no vulnerabilities are found, it displays a message indicating that no vulnerabilities were found. Additionally, if any unmaintained packages are detected, a warning message is displayed. This change enhances the security of the project by ensuring that vulnerabilities and unmaintained packages are identified during the CI/CD process.